### PR TITLE
Fixed crash when num children in panel is < 2

### DIFF
--- a/ModalJS.uno
+++ b/ModalJS.uno
@@ -230,8 +230,8 @@ namespace Bolav.Modal {
 			if defined(CIL) {
 				if (n is Fuse.Desktop.DesktopRootViewport) {
 					var a = n as Fuse.Desktop.DesktopRootViewport;
-					var c = a.Children[1];
-					debug_log a.Children.Count;
+					debug_log "Num Children: " + a.Children.Count;
+					var c = a.Children[a.Children.count-1];
 					return FindPanel(c);
 				}
 			}


### PR DESCRIPTION
This should fix an issue with this library in Fuse 0.37 in preview mode.