### PR TITLE
use Node.FirstChild<T> instead of custom search

### DIFF
--- a/ModalJS.uno
+++ b/ModalJS.uno
@@ -217,29 +217,12 @@ namespace Bolav.Modal {
 				return null;
 			}
 			else {
-				parent = FindPanel(AppBase.Current.RootViewport);
+				parent = AppBase.Current.RootViewport.FirstChild<Panel>();
 				myPanel = UXModal(title, body, buttons);
 				UpdateManager.PostAction(AddModalUX);
 				return null;
 			}
 
-		}
-
-		Panel FindPanel (Node n) {
-			debug_log "FindPanel " + n;
-			if defined(CIL) {
-				if (n is Fuse.Desktop.DesktopRootViewport) {
-					var a = n as Fuse.Desktop.DesktopRootViewport;
-					debug_log "Num Children: " + a.Children.Count;
-					var c = a.Children[a.Children.Count-1];
-					return FindPanel(c);
-				}
-			}
-			if (n is Fuse.Controls.Panel) {
-				var p = n as Fuse.Controls.Panel;
-				return p;
-			}
-			return null;
 		}
 	}
 }


### PR DESCRIPTION
The custom search-method references Fuse.Desktop.DesktopRootViewport,
which is not public. This probably just worked because of a
visibility-bug in uno that has been fixed.

So to avoid breaking with Fuse 1.3, let's just use Node.FirstChild<T>
instead. It does what we want.